### PR TITLE
Including single replica failure chaos test in packet pipeine

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -252,6 +252,12 @@ repl-kill-{percona-jiva}:
   script:
    - ./script/apps/percona/chaos/jiva/volume-replica-failure
 
+## Single replica failure
+single-repl-kill-{percona-jiva}:
+  extends: .chaos_test_template #dependencies: percona-jiva-single-replica
+  script:
+   - ./script/apps/percona/chaos/jiva/single-replica-failure
+
 ctrl-kill-{mongo-jiva}:
   extends: .chaos_test_template #dependencies: mongo-jiva
   script:

--- a/script/apps/percona/chaos/jiva/single-replica-failure
+++ b/script/apps/percona/chaos/jiva/single-replica-failure
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -x
+
+#################
+## ENVIRONMENT ##
+#################
+
+## https://github.com/openebs/litmus/blob/master/apps/percona/chaos/openebs_volume_replica_failure/test_vars.yml
+run_id="single";test_name=$(${utils_path}/generate_test_name testcase=openebs-volume-replica-failure metadata=${run_id})
+
+###################
+## DEPENDENCIES  ##
+###################
+
+${utils_path}/setup_dependencies litmus-test
+
+## Clone the litmus repo, checkout the e2e branch, navigate to litmus root 
+
+git clone https://github.com/openebs/litmus.git
+cd litmus
+
+############################
+## LITMUS PRECONDITIONING ##
+############################
+
+cp apps/percona/chaos/openebs_volume_replica_failure/run_litmus_test.yml run_test.yml 
+
+sed -i -e 's/name: openebs-volume-replica-failure/name: jiva-single-replica-failure/g' \
+-e 's/value: app-percona-ns/value: percona-single-replica/g' run_test.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' run_test.yml
+
+#################
+## RUNNER MAIN ##
+#################
+
+echo "Running the litmus test.."
+${utils_path}/litmus_job_runner label='name:jiva-single-replica-failure' job=run_test.yml
+${utils_path}/task_delimiter;
+
+echo "Dumping state of cluster post job run"; echo ""
+${utils_path}/dump_cluster_state;
+${utils_path}/task_delimiter;
+
+#################
+## GET RESULT  ##
+#################
+
+## Check the test status & result from the litmus result custom resource
+${utils_path}/get_litmus_result ${test_name}


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

- Included single replica failure executor script which runs against percona single replica deployment.
- Included the above job in chaos stage.