### PR TITLE
Update the image and k8s version to 1.12 for the platform.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
 # Setup the kubernetes cluster
 
 packet-cluster:
-  image: chandankumar4/packet:v4
+  image: openebs/packet-ci:latest
   stage: CLUSTER-SETUP 
   script:
     - mkdir -p ~/.ssh && ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
@@ -31,7 +31,7 @@ packet-cluster:
 ## Setup OpenEBS control plane
 
 openebs-packet-deploy:
-  image: atulabhi/kops:v8
+  image: openebs/packet-ci:latest
   stage: PROVIDER-INFRA-SETUP
   dependencies:
     - packet-cluster
@@ -42,7 +42,7 @@ openebs-packet-deploy:
       - openebs-packet/
 
 openebs-sc-deploy:
-  image: atulabhi/kops:v8
+  image: openebs/packet-ci:latest
   stage: PROVIDER-INFRA-SETUP
   dependencies:
     - packet-cluster
@@ -56,7 +56,7 @@ openebs-sc-deploy:
 ## Define a job template for app deployers
 
 .app_deploy_template:
-  image: atulabhi/kops:v8
+  image: openebs/packet-ci:latest
   stage: STATEFUL-APP-DEPLOY 
   dependencies:
     - openebs-packet-deploy
@@ -190,7 +190,7 @@ prometheus-cstor-run/load/check:
 ## Define job template for func test jobs  
 
 .func_test_template:
-  image: atulabhi/kops:v8
+  image: openebs/packet-ci:latest
   stage: APP-FUNC-TEST
   when: always 
   artifacts:
@@ -253,7 +253,7 @@ app-upgrade-deployment-{jenkins-cstor}:
 ## Define job template for chaos jobs 
 
 .chaos_test_template:
-  image: atulabhi/kops:v8
+  image: openebs/packet-ci:latest
   stage: APP-CHAOS-TEST
   when: always 
   artifacts:
@@ -307,7 +307,7 @@ tgt-disconnect-{mongo-cstor}:
    - ./script/apps/mongo/chaos/cstor/volume-target-network-delay
 
 .app_deprovision_template:
-  image: atulabhi/kops:v8
+  image: openebs/packet-ci:latest
   stage: APP-DEPROVISION
   when: always
   artifacts:

--- a/script/packet
+++ b/script/packet
@@ -8,7 +8,7 @@ export PACKET_API_TOKEN=$packet_api_token
 git clone https://github.com/openebs/litmus.git
 cd litmus/k8s/packet/k8s-installer
 echo "--------------- creating packet cluster --------------------"
-ansible-playbook create_packet_cluster.yml --extra-vars "k8s_version=1.10.0-00" -v
+ansible-playbook create_packet_cluster.yml --extra-vars "k8s_version=1.12.6-00" -v
 kubectl get nodes
 kubectl get pods --all-namespaces
 kubectl apply -f https://raw.githubusercontent.com/openebs/litmus/master/hack/rbac.yaml


### PR DESCRIPTION
- Update k8s version to 1.12.6-00.
- Use the latest openebs/packet-ci:latest image for GitLab to reduce docker pull time.

Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>