### PR TITLE
Include job validation in packet cluster setup/cleanup

### DIFF
--- a/script/packet
+++ b/script/packet
@@ -9,9 +9,15 @@ git clone https://github.com/litmuschaos/litmus.git
 cd litmus/k8s/packet/k8s-installer
 echo "--------------- creating packet cluster --------------------"
 ansible-playbook create_packet_cluster.yml --extra-vars "k8s_version=1.13.5-00" -v
+if [ "$?" != "0" ]; then
+exit 1;
+fi
 echo "--------------Attaching disks to the nodes------------------"
 cd ../packet-storage
-ansible-playbook create-volume.yml -vv --extra-vars "packet_api=$packet_api_token"
+ansible-playbook create-volume.yml -vv --extra-vars "packet_api=$packet_api_token disk_action=format"
+if [ "$?" != "0" ]; then
+exit 1;
+fi
 kubectl get nodes
 kubectl get pods --all-namespaces
 kubectl apply -f https://raw.githubusercontent.com/litmuschaos/litmus/master/hack/rbac.yaml

--- a/script/packet-cleanup
+++ b/script/packet-cleanup
@@ -12,9 +12,15 @@ export PACKET_API_TOKEN=$packet_api_token
 git clone https://github.com/litmuschaos/litmus.git
 cd litmus/k8s/packet/k8s-installer
 echo "--------------- deleting packet cluster --------------------"
-ansible-playbook delete_packet_cluster.yml -vv
+ansible-playbook delete_packet_cluster.yml -vv --extra-vars "packet_api=$packet_api_token"
+if [ "$?" != "0" ]; then
+exit 1;
+fi
 echo "----------------deleting volumes ---------------------------"
 cd ../packet-storage
 cp -r $path/cluster/volume_id /tmp/packet/
 ansible-playbook delete-volume.yml -vv --extra-vars "packet_api=$packet_api_token"
+if [ "$?" != "0" ]; then
+exit 1;
+fi
 


### PR DESCRIPTION
- Include job validation (If ansible command for cluster creation/deletion fails then the corresponding job of pipeline will also fail ) in packet cluster setup/cleanup.
- Change the packet cleanup ansible command (As now **packet_api_token** need to be passed as extra vars). 